### PR TITLE
Issue 70: InstanceGroups non zone parsing fix.

### DIFF
--- a/plugin/authorizer_client_gcp.go
+++ b/plugin/authorizer_client_gcp.go
@@ -24,7 +24,7 @@ func genExtractZonesFn(igz map[string][]string, boundInstanceGroups []string) fu
 		for k, v := range l.Items {
 			zone, err := zoneFromSelfLink(k)
 			if err != nil {
-				return err
+				continue
 			}
 			for _, g := range v.InstanceGroups {
 				if strutil.StrListContains(boundInstanceGroups, g.Name) {


### PR DESCRIPTION
We simply continue to extract zones if we have an error in zoneFromSelfLink.

Test now passes:

Test ran:
```
go test ./plugin/... -run TestInstanceGroups -v
```